### PR TITLE
Cleaner and Simpler Version of printing to stdout

### DIFF
--- a/script/esprint.py
+++ b/script/esprint.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 
-import sys
-import time
+from time import sleep
 
 def delay(s):
     for c in s:
-        sys.stdout.write(c)
-        sys.stdout.flush()
-        time.sleep(0.01)
+        print(c, end='', flush=True)
+        sleep(0.01)
 
 delay
 delay ("\033[48;5;0;38;5;197m Please, Enter Correct Number!")


### PR DESCRIPTION
print() is default to stdout.
from time import sleep is way better because it doesn't require loading the whole library